### PR TITLE
Add initial README for Rust learning repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Rust Learning Repository
+
+This repository is dedicated to learning the Rust programming language. It contains a collection of code examples to illustrate various Rust concepts and features.
+
+## How to Use
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository_url>
+    cd <repository_directory>
+    ```
+    (Replace `<repository_url>` and `<repository_directory>` with the actual URL and directory name)
+
+2.  **Navigate to an example:**
+    Examples will be organized in directories (once added). You'll `cd` into the specific example's directory.
+
+3.  **Run the example:**
+    Most examples can be run using Cargo, Rust's package manager and build system:
+    ```bash
+    cargo run
+    ```
+
+## Examples
+
+This section will be updated with links to or descriptions of the examples as they are added. Currently, the repository contains a basic "Hello, world!" application in `src/main.rs`.
+
+## Contributing
+
+This repository is primarily for personal learning. However, if you have simple, illustrative examples that you think would be beneficial, feel free to suggest them.


### PR DESCRIPTION
This README introduces the repository's purpose, which is to host Rust learning examples. It includes sections on how to use the examples and a placeholder for future content.